### PR TITLE
hide additional / original date range forms on campaign pages

### DIFF
--- a/app/bundles/CoreBundle/Assets/js/93.campaign-hide-daterange-forms.js
+++ b/app/bundles/CoreBundle/Assets/js/93.campaign-hide-daterange-forms.js
@@ -1,0 +1,13 @@
+// hide all original daterange forms since we add our own in a custom widget
+Mautic.campaignHideDateFilterForms = function () {
+    mQuery('form[name="daterange"]:not(:first)').remove();
+};
+
+mQuery(document).ready(function () {
+    Mautic.campaignHideDateFilterForms();
+});
+mQuery(document).ajaxComplete(function (event, xhr, settings) {
+    setTimeout(function(){
+        Mautic.campaignHideDateFilterForms();
+    }, 150);
+});


### PR DESCRIPTION
the campaign page has a broken daterange form. This PR removes it.